### PR TITLE
fix open tag range including leading whitespace

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -197,6 +197,11 @@ export function parseForESLint(code: string, options?: any): ESLintHtmlParseResu
             tokens.push(currentElement);
         },
 
+        onopentagend: (name: string) => {
+            currentElement.range[0] = htmlParser.startIndex;
+            currentElement.loc.start = getLineAndColumn(htmlParser.startIndex);
+        },
+
         onclosetag: () => {
             currentElement.range[1] = htmlParser.endIndex + 1;
             currentElement.loc.end = getLineAndColumn(htmlParser.endIndex + 1);

--- a/index.ts
+++ b/index.ts
@@ -193,13 +193,10 @@ export function parseForESLint(code: string, options?: any): ESLintHtmlParseResu
     };
 
     let parseHandler: Partial<DomHandler> = {
-        onopentag: (name: string) => {
+        onopentag: (name: string) => {   
+            currentElement.range[0] = htmlParser.startIndex
+            currentElement.loc.start = getLineAndColumn(htmlParser.startIndex)
             tokens.push(currentElement);
-        },
-
-        onopentagend: (name: string) => {
-            currentElement.range[0] = htmlParser.startIndex;
-            currentElement.loc.start = getLineAndColumn(htmlParser.startIndex);
         },
 
         onclosetag: () => {


### PR DESCRIPTION
Elements had been including leading whitespace when parsed (might have been all text, but noticed with whitespace). The issue was that when an `HTMLElement` is created with `onopentag`, the parser's position (`startIndex`) hadn't been updated yet.

[`Parser#onopentagname`](https://github.com/fb55/htmlparser2/blob/master/src/Parser.ts#L243-L272) does not call [`Parser#updatePosition`](https://github.com/fb55/htmlparser2/blob/master/src/Parser.ts#L223-L234) (unless the tag is implied closed (https://github.com/fb55/htmlparser2/blob/master/src/Parser.ts#L253-L260)). This means that after the call to `onopentag`, `Parser#startIndex` is the same as it was before the call. Which means that `currentElement.loc.start` is set to whatever the start of the previous thing was.

At the end of an open HTML tag, [`Parser#onopentagend`](https://github.com/fb55/htmlparser2/blob/master/src/Parser.ts#L274-L288) is called and calls `Parser#updatePosition` to set `Parser#startIndex` to the beginning of the tag.

So, this PR has `onopentag` set the starting `loc` and `range`.

&nbsp;

Between the `Parser#onopentagname` call and the `Parser#onopentagend` call, nothing in the parser will call `updatePosition`. Meaning that when we are in the `onopentag` callback we will not have missed anything and `startIndex` will be correct.