### PR TITLE
newline chars should be part of the current line

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -69,7 +69,7 @@ export function parseForESLint(code: string, options?: any): ESLintHtmlParseResu
         let tabNumber: number = -1;
 
         while (++tabNumber < tabIndices.length) {
-            if (tabIndices[tabNumber] < lineBreakIndices[lineNumber - 1]) {
+            if (tabIndices[tabNumber] <= lineBreakIndices[lineNumber - 1]) {
                 continue;
             }
 


### PR DESCRIPTION
Came across an error when parsing some HTML where the end line was incorrect and column was set to -1. This fixes that.